### PR TITLE
expose roster to other items

### DIFF
--- a/client/roster.coffee
+++ b/client/roster.coffee
@@ -1,17 +1,46 @@
+# Sample Roster Accessing Code
+#
+# Any item that exploses a roster will be identifed with class "roster-source".
+# These items offer the method getRoster() for retrieving the roster object.
+# Convention has roster consumers looking left for the nearest (or all) such objects. 
+#
+#     items = $(".item:lt(#{$('.item').index(div)})")
+#     if (sources = items.filter ".roster-source").size()
+#       choice = sources[sources.length-1]
+#       roster = choice.getRoster()
+#
+# This simplified version might be useful from the browser's javascript inspector.
+#
+#     $('.roster-source').get(0).getRoster()
 
-flag = (site) ->
-  "<img class=\"remote\" src=\"//#{site}/favicon.png\" title=\"#{site}\" data-site=\"#{site}\" data-slug=\"welcome-visitors\">"
-
-expand = (text)->
-  text
-    .replace /&/g, '&amp;'
-    .replace /</g, '&lt;'
-    .replace />/g, '&gt;'
-    .replace /\*(.+?)\*/g, '<i>$1</i>'
-    .replace /^$/, '<br>'
-    .replace /^([a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)+)$/, flag('$1')
 
 emit = ($item, item) ->
+  roster = {all: []}
+  category = null
+
+  flag = (site) ->
+    roster.all.push site
+    if category?
+      roster[category] ||= []
+      roster[category].push site
+     "<img class=\"remote\" src=\"//#{site}/favicon.png\" title=\"#{site}\" data-site=\"#{site}\" data-slug=\"welcome-visitors\">"
+
+  cat = (name) ->
+    category = name
+
+  expand = (text)->
+    text
+      .replace /&/g, '&amp;'
+      .replace /</g, '&lt;'
+      .replace />/g, '&gt;'
+      .replace /\*(.+?)\*/g, '<i>$1</i>'
+      .replace /^$/, '<br>'
+      .replace /^([a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)+)$/, flag
+      .replace /^([^<].*)$/, cat
+
+
+  $item.addClass 'roster-source'
+  $item.get(0).getRoster = -> roster
   lines = (expand(line) for line in item.text.split /\r?\n/)
   $item.append """
     <p style="background-color:#eee;padding:15px;">
@@ -22,6 +51,7 @@ emit = ($item, item) ->
 bind = ($item, item) ->
   $item.dblclick -> wiki.textEditor $item, item
 
+
 window.plugins.roster = {emit, bind} if window?
-module.exports = {expand} if module?
+module.exports = {} if module?
 


### PR DESCRIPTION
This commit adds logic to expose the contents of a Roster plugin as a structured javascript object.

Any item can offer Rosters. Items that are ready to do so identify themselves with class `roster-source`. These items will return the roster in response to method `getRoster()`.

This commit adds comments that suggest how a roster consumer would look for rosters in the lineup. A simple version of this suitable for evaluation in the javascript console would be:

```
$('.roster-source').get(0).getRoster()
```

The roster is structured with keys identifying sections where one key, "all", represents all available sites.

```
{
    'all': [ 'site1.example.com', ... ],
    'Label 1': [ ... ],
    'Label 2': [ ... ],
    ...
}
```

This is the same mechanism used by D3-Line and Radar plugins to render data from various plugins.
