### PR TITLE
Add lineup-links (▶︎) to browse whole rows of roster.

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,0 +1,4 @@
+Authors ordered by first contribution
+
+Ward Cunningham <ward@c2.com>
+Paul Rodwell <paul.rodwell@btinternet.com>

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,41 @@
+Copyright (c) 2015 Ward Cunningham and other contributors
+
+This software consists of voluntary contributions made by many
+individuals. For exact contribution history, see the revision history
+available at https://github.com/fedwiki/wiki-plugin-roster
+
+The following license applies to all parts of this software except as
+documented below:
+
+====
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+====
+
+All files located in the pages directory are licensed under a
+Creative Commons Attribution-ShareAlike 4.0 International License.
+
+CC BY-SA 4.0 : http://creativecommons.org/licenses/by-sa/4.0/
+
+====
+
+All files located in the node_modules directory are externally maintained
+libraries used by this software which have their own licenses; we recommend
+you read them, as their terms may differ from the terms above.

--- a/client/roster.coffee
+++ b/client/roster.coffee
@@ -1,18 +1,61 @@
+# Sample Roster Accessing Code
+#
+# Any item that exploses a roster will be identifed with class "roster-source".
+# These items offer the method getRoster() for retrieving the roster object.
+# Convention has roster consumers looking left for the nearest (or all) such objects.
+#
+#     items = $(".item:lt(#{$('.item').index(div)})")
+#     if (sources = items.filter ".roster-source").size()
+#       choice = sources[sources.length-1]
+#       roster = choice.getRoster()
+#
+# This simplified version might be useful from the browser's javascript inspector.
+#
+#     $('.roster-source').get(0).getRoster()
 
-flag = (site) ->
-  "<img class=\"remote\" src=\"//#{site}/favicon.png\" title=\"#{site}\" data-site=\"#{site}\" data-slug=\"welcome-visitors\">"
-
-expand = (text)->
-  text
-    .replace /&/g, '&amp;'
-    .replace /</g, '&lt;'
-    .replace />/g, '&gt;'
-    .replace /\*(.+?)\*/g, '<i>$1</i>'
-    .replace /^$/, '<br>'
-    .replace /^([a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)+)$/, flag('$1')
 
 emit = ($item, item) ->
+  roster = {all: []}
+  category = null
+  lineup = []
+
+  flag = (site) ->
+    roster.all.push site
+    lineup.push site
+    br = if lineup.length >= 18
+      newline()
+    else
+      ''
+    if category?
+      roster[category] ||= []
+      roster[category].push site
+    "<img class=\"remote\" src=\"//#{site}/favicon.png\" title=\"#{site}\" data-site=\"#{site}\" data-slug=\"welcome-visitors\">#{br}"
+
+  newline = ->
+    if lineup.length > 1
+      sites = lineup.join '/'
+      lineup = []
+      """ <a class='conversation' href= "#" data-sites="#{sites}">▶︎</a><br> """
+    else
+      "<br>"
+
+  cat = (name) ->
+    category = name
+
+  expand = (text)->
+    text
+      .replace /&/g, '&amp;'
+      .replace /</g, '&lt;'
+      .replace />/g, '&gt;'
+      .replace /\*(.+?)\*/g, '<i>$1</i>'
+      .replace /^$/, newline
+      .replace /^([a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)+)$/, flag
+      .replace /^([^<].*)$/, cat
+
+  $item.addClass 'roster-source'
+  $item.get(0).getRoster = -> roster
   lines = (expand(line) for line in item.text.split /\r?\n/)
+  lines.push newline()
   $item.append """
     <p style="background-color:#eee;padding:15px;">
       #{lines.join ' '}
@@ -21,7 +64,10 @@ emit = ($item, item) ->
 
 bind = ($item, item) ->
   $item.dblclick -> wiki.textEditor $item, item
+  $item.find('conversation').click (e) ->
+    e.preventDefault()
+    e.stopPropagation()
+    console.log 'conversation sites', $(e.target).data(sites)
 
 window.plugins.roster = {emit, bind} if window?
-module.exports = {expand} if module?
-
+module.exports = {} if module?

--- a/client/roster.coffee
+++ b/client/roster.coffee
@@ -50,6 +50,7 @@ emit = ($item, item) ->
       .replace /\*(.+?)\*/g, '<i>$1</i>'
       .replace /^$/, newline
       .replace /^([a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)+)(:\d+)?$/, flag
+      .replace /^localhost(:\d+)?$/, flag
       .replace /^([^<].*)$/, cat
 
   $item.addClass 'roster-source'

--- a/client/roster.coffee
+++ b/client/roster.coffee
@@ -49,7 +49,7 @@ emit = ($item, item) ->
       .replace />/g, '&gt;'
       .replace /\*(.+?)\*/g, '<i>$1</i>'
       .replace /^$/, newline
-      .replace /^([a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)+)$/, flag
+      .replace /^([a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)+)(:\d+)?$/, flag
       .replace /^([^<].*)$/, cat
 
   $item.addClass 'roster-source'

--- a/client/roster.coffee
+++ b/client/roster.coffee
@@ -13,6 +13,14 @@
 #
 #     $('.roster-source').get(0).getRoster()
 
+open_conversation = (this_page, uri) ->
+  tuples = uri.split '/'
+  tuples.shift()
+  while tuples.length
+    site = tuples.shift()
+    slug = tuples.shift()
+    wiki.doInternalLink slug, this_page, site
+    this_page = null
 
 emit = ($item, item) ->
   roster = {all: []}
@@ -33,9 +41,9 @@ emit = ($item, item) ->
 
   newline = ->
     if lineup.length > 1
-      sites = lineup.join '/'
+      sites = ("/#{site}/welcome-visitors" for site in lineup)
       lineup = []
-      """ <a class='conversation' href= "#" data-sites="#{sites}">▶︎</a><br> """
+      """ <a class='conversation' href= "/#" data-sites="#{sites.join ''}">▶︎</a><br> """
     else
       "<br>"
 
@@ -65,10 +73,12 @@ emit = ($item, item) ->
 
 bind = ($item, item) ->
   $item.dblclick -> wiki.textEditor $item, item
-  $item.find('conversation').click (e) ->
+  $item.find('.conversation').click (e) ->
     e.preventDefault()
     e.stopPropagation()
-    console.log 'conversation sites', $(e.target).data(sites)
+    console.log 'conversation sites', $(e.target).data('sites').split('/')
+    this_page = $item.parents('.page') unless e.shiftKey
+    open_conversation this_page, $(e.target).data('sites')
 
 window.plugins.roster = {emit, bind} if window?
 module.exports = {} if module?

--- a/client/roster.coffee
+++ b/client/roster.coffee
@@ -1,8 +1,15 @@
+###
+ * Federated Wiki : Roster Plugin
+ *
+ * Licensed under the MIT license.
+ * https://github.com/fedwiki/wiki-plugin-roster/blob/master/LICENSE.txt
+###
+#
 # Sample Roster Accessing Code
 #
 # Any item that exploses a roster will be identifed with class "roster-source".
 # These items offer the method getRoster() for retrieving the roster object.
-# Convention has roster consumers looking left for the nearest (or all) such objects.
+# Convention has roster consumers looking left for the nearest (or all) such objects. 
 #
 #     items = $(".item:lt(#{$('.item').index(div)})")
 #     if (sources = items.filter ".roster-source").size()
@@ -79,6 +86,7 @@ bind = ($item, item) ->
     console.log 'conversation sites', $(e.target).data('sites').split('/')
     this_page = $item.parents('.page') unless e.shiftKey
     open_conversation this_page, $(e.target).data('sites')
+
 
 window.plugins.roster = {emit, bind} if window?
 module.exports = {} if module?

--- a/factory.json
+++ b/factory.json
@@ -1,5 +1,5 @@
 {
   "name": "Roster",
   "title": "Roster Plugin",
-  "category": "data|format|other"
+  "category": "other"
 }

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -33,6 +33,24 @@ module.exports = function (grunt) {
     }
   });
 
+  grunt.registerTask( "update-authors", function () {
+    var getAuthors = require("grunt-git-authors"),
+    done = this.async();
+
+    getAuthors({
+      priorAuthors: grunt.config( "authors.prior")
+      }, function(error, authors) {
+        if (error) {
+          grunt.log.error(error);
+          return done(false);
+        }
+
+        grunt.file.write("AUTHORS.txt",
+          "Authors ordered by first contribution\n\n" +
+          authors.join("\n") + "\n");
+      });
+  });
+
   grunt.registerTask('build', ['coffee', 'mochaTest']);
   grunt.registerTask('default', ['build']);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki-plugin-roster",
-  "version": "0.0.1",
+  "version": "0.1.2",
   "description": "Federated Wiki - Roster Plugin",
   "keywords": [
     "roster",
@@ -9,9 +9,9 @@
     "plugin"
   ],
   "author": {
-    "name": "Your Name",
-    "email": "you@example.com",
-    "url": "http://example.com"
+    "name": "Ward Cunningham",
+    "email": "ward@c2.com",
+    "url": "http://ward.fed.wiki.org"
   },
   "contributors": [],
   "scripts": {
@@ -23,9 +23,15 @@
     "grunt-contrib-watch": "~0.6",
     "mocha": "*",
     "expect.js": "*",
-    "grunt-mocha-test": "~0.12"
+    "grunt-mocha-test": "~0.12",
+    "grunt-git-authors": "~2"
   },
-  "license": "MIT",
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://github.com/fedwiki/wiki-plugin-roster/blob/master/LICENSE.txt"
+    }
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/fedwiki/wiki-plugin-roster.git"


### PR DESCRIPTION
This pull request is for evaluation only. We address some but not all of the discussion in issue #1.

This has been a long-running branch that may not have tracked master correctly. I'm disappointed that it won't merge cleanly since I thought I'd attended to that.

There remains ui performance problems when loading many sitemaps at once. The fix for this is probably in core and therefore outside of work in this repo.
