### PR TITLE
include roster from remote page

### DIFF
--- a/client/roster.coffee
+++ b/client/roster.coffee
@@ -42,6 +42,10 @@ parse = ($item, item) ->
   marks = {}
   lines = []
 
+  if $item?
+    $item.addClass 'roster-source'
+    $item.get(0).getRoster = -> roster
+
   more = item.text.split /\r?\n/
 
   flag = (site) ->
@@ -102,8 +106,6 @@ parse = ($item, item) ->
   lines.join ' '
 
 emit = ($item, item) ->
-  $item.addClass 'roster-source'
-  $item.get(0).getRoster = -> roster
   $item.append """
     <p style="background-color:#eee;padding:15px;">
       #{parse $item, item}

--- a/client/roster.coffee
+++ b/client/roster.coffee
@@ -55,21 +55,21 @@ parse = ($item, item) ->
       newline()
     else
       ''
-    if category?
-      roster[category] ||= []
-      roster[category].push site
     "<img class=\"remote\" src=\"//#{site}/favicon.png\" title=\"#{site}\" data-site=\"#{site}\" data-slug=\"welcome-visitors\">#{br}"
 
   newline = ->
     if lineup.length
-      sites = ("#{site}" for site in lineup)
-      lineup = []
+      [sites, lineup] = [lineup, []]
+      if category?
+        roster[category] ||= []
+        roster[category].push site for site in sites
       """ <a class='loadsites' href= "/#" data-sites="#{sites.join ' '}" title="add these #{sites.length} sites\nto neighborhood">»</a><br> """
     else
       "<br>"
 
   cat = (name) ->
     category = name
+
     # escape name
 
   include = (line, siteslug) ->
@@ -113,7 +113,11 @@ emit = ($item, item) ->
   """
 
 bind = ($item, item) ->
-  $item.dblclick -> wiki.textEditor $item, item
+  $item.dblclick (e) ->
+    if e.shiftKey
+      wiki.dialog "Roster Categories", "<pre>#{JSON.stringify $item.get(0).getRoster(), null, 2}</pre>"
+    else
+      wiki.textEditor $item, item
   $item.find('.loadsites').click (e) ->
     e.preventDefault()
     e.stopPropagation()

--- a/client/roster.coffee
+++ b/client/roster.coffee
@@ -70,9 +70,7 @@ parse = ($item, item) ->
   cat = (name) ->
     category = name
 
-    # escape name
-
-  include = (line, siteslug) ->
+  includeRoster = (line, siteslug) ->
     if marks[siteslug]?
       return "<span>trouble looping #{siteslug}</span>"
     else
@@ -92,12 +90,28 @@ parse = ($item, item) ->
         bind $item, item
       "<span>loading #{siteslug}</span>"
 
+  includeReferences = (line, siteslug) ->
+    if includes[siteslug]?
+      [].unshift.apply more, includes[siteslug]
+      ''
+    else
+      $.getJSON "http://#{siteslug}.json", (page) ->
+        includes[siteslug] = []
+        for i in page.story
+          if i.type is 'reference'
+            includes[siteslug].push i.site if includes[siteslug].indexOf(i.site) < 0
+        $item.empty()
+        emit $item, item
+        bind $item, item
+      "<span>loading #{siteslug}</span>"
+
   expand = (text) ->
     text
       .replace /^$/, newline
       .replace /^([a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)+)(:\d+)?$/, flag
       .replace /^localhost(:\d+)?$/, flag
-      .replace /^INCLUDE ([A-Za-z0-9.-:]+\/[a-z0-9-]+)$/, include
+      .replace /^ROSTER ([A-Za-z0-9.-:]+\/[a-z0-9-]+)$/, includeRoster
+      .replace /^REFERENCES ([A-Za-z0-9.-:]+\/[a-z0-9-]+)$/, includeReferences
       .replace /^([^<].*)$/, cat
 
   while more.length

--- a/client/roster.coffee
+++ b/client/roster.coffee
@@ -35,12 +35,14 @@ load_sites = (uri) ->
     site = tuples.shift()
     wiki.neighborhoodObject.registerNeighbor site
 
-emit = ($item, item) ->
+parse = ($item, item) ->
   roster = {all: []}
   category = null
   lineup = []
-  more = []
   marks = {}
+  lines = []
+
+  more = item.text.split /\r?\n/
 
   flag = (site) ->
     roster.all.push site
@@ -55,10 +57,10 @@ emit = ($item, item) ->
     "<img class=\"remote\" src=\"//#{site}/favicon.png\" title=\"#{site}\" data-site=\"#{site}\" data-slug=\"welcome-visitors\">#{br}"
 
   newline = ->
-    if lineup.length > 1
+    if lineup.length
       sites = ("#{site}" for site in lineup)
       lineup = []
-      """ <a class='loadsites' href= "/#" data-sites="#{sites.join ' '}">»</a><br> """
+      """ <a class='loadsites' href= "/#" data-sites="#{sites.join ' '}" title="add these #{sites.length} sites\nto neighborhood">»</a><br> """
     else
       "<br>"
 
@@ -83,6 +85,7 @@ emit = ($item, item) ->
             break
         $item.empty()
         emit $item, item
+        bind $item, item
       "<span>loading #{siteslug}</span>"
 
   expand = (text) ->
@@ -93,19 +96,17 @@ emit = ($item, item) ->
       .replace /^INCLUDE ([A-Za-z0-9.-:]+\/[a-z0-9-]+)$/, include
       .replace /^([^<].*)$/, cat
 
-  parse = (text) ->
-    lines = []
-    more = text.split /\r?\n/
-    while more.length
-      lines.push expand more.shift()
-    lines.push newline()
-    lines.join ' '
+  while more.length
+    lines.push expand more.shift()
+  lines.push newline()
+  lines.join ' '
 
+emit = ($item, item) ->
   $item.addClass 'roster-source'
   $item.get(0).getRoster = -> roster
   $item.append """
     <p style="background-color:#eee;padding:15px;">
-      #{parse item.text}
+      #{parse $item, item}
     </p>
   """
 
@@ -119,4 +120,4 @@ bind = ($item, item) ->
 
 
 window.plugins.roster = {emit, bind} if window?
-module.exports = {} if module?
+module.exports = {parse, includes} if module?

--- a/pages/about-roster-plugin
+++ b/pages/about-roster-plugin
@@ -1,37 +1,550 @@
 {
   "title": "About Roster Plugin",
   "story": [
-  {
-    "type": "paragraph",
-    "id": "7764988b30d81458",
-    "text": "This plugin provides a hoverable, clickable roster of sites participating in a group activity."
-  },
-  {
-    "type": "roster",
-    "id": "1eae75c847715275",
-    "text": "Mike Caulfield\n\nmachines.hapgood.net\norientation.hapgood.net\n\nWard Cunningham\n\nward.fed.wiki.org\nward.asia.wiki.org\nforage.ward.fed.wiki.org\nh2.ward.asia.wiki.org\n\nHappening #2\n\naudrey.sf.fedwikihappening.net\nanderhaff.ny2.fedwikihappening.net\ncards.aribadernatal.com\nniallb.uk2.fedwikihappening.net\nfrances.uk2.fedwikihappening.net\ncj13.sf2.fedwikihappening.net\nphb256.ny2.fedwikihappening.net\nfortyfoxes.uk2.fedwikihappening.net\ntmtm.uk2.fedwikihappening.net\nkate.au.fedwikihappening.net\ndancallahan.ny2.fedwikihappening.net\ngardnercampbell.ny2.fedwikihappening.net\nchamboonline.sf2.fedwikihappening.net\ntimothyfcook.ny2.fedwikihappening.net\nh2.ward.asia.wiki.org\nadamldavis.ny2.fedwikihappening.net\ntdeflitch.ny2.fedwikihappening.net\npodehaye.uk2.fedwikihappening.net\njrdingwall.sf2.fedwikihappening.net\nkimeke.ny2.fedwikihappening.net\ntelliowkuwp.ny2.fedwikihappening.net\nerbfarm.ny2.fedwikihappening.net\nadrianoferrari.ny2.fedwikihappening.net\nhypervisible.ny2.fedwikihappening.net\ndongorges.ny2.fedwikihappening.net\nelectricarchaeo.ny2.fedwikihappening.net\nfgraver.uk2.fedwikihappening.net\ndaveh70.ny2.fedwikihappening.net\nkwhamon.ny2.fedwikihappening.net\nchaugen.sf2.fedwikihappening.net\ncamhock.ny2.fedwikihappening.net\ndogtrax.ny2.fedwikihappening.net\ntuttlesvc.ny2.fedwikihappening.net\ndonalholland.ny2.fedwikihappening.net\nsarah.uk.fedwikihappening.net\nhwangmoretime.sf2.fedwikihappening.net\nmachines.alyson.sf.fedwikihappening.net\ntheotherjeff.sf2.fedwikihappening.net\ngeonz.ny2.fedwikihappening.net\nfedwiki.djon.es\ntomaskafka.uk2.fedwikihappening.net\nthoka.uk2.fedwikihappening.net\nnick.uk.fedwikihappening.net\ncjunekim.sf2.fedwikihappening.net\ntim.au.fedwikihappening.net\nnlafferty.uk2.fedwikihappening.net\ncogdoghappening.sf2.fedwikihappening.net\nmartinlindner.uk2.fedwikihappening.net\njenny.uk.fedwikihappening.net\nannalisamanca.uk2.fedwikihappening.net\nx28de.uk2.fedwikihappening.net\nSbethm.sf2.fedwikihappening.net\nmcmorgan.ny2.fedwikihappening.net\nbrackenm.ny2.fedwikihappening.net\ncicatriz.ny2.fedwikihappening.net\nottonomy.sf2.fedwikihappening.net\njupidu.uk2.fedwikihappening.net\n14prinsp.ny2.fedwikihappening.net\nreimerth.uk2.fedwikihappening.net\nwiki.allmende.io\nemily.edfedwiki.com\nfedwiki.jeffist.com\npatchcr.ny2.fedwikihappening.net\nfedwiki.jakesandlund.com\nmshook.ny2.fedwikihappening.net"
-  }
-],
-  "journal": [
-  {
-    "type": "create",
-    "item": {
-      "title": "About Roster Plugin",
-      "story": [
-  {
-    "type": "paragraph",
-    "id": "7764988b30d81458",
-    "text": "This plugin provides a hoverable, clickable roster of sites participating in a group activity."
-  },
-  {
-    "type": "roster",
-    "id": "1eae75c847715275",
-    "text": "Mike Caulfield\n\nmachines.hapgood.net\norientation.hapgood.net\n\nWard Cunningham\n\nward.fed.wiki.org\nward.asia.wiki.org\nforage.ward.fed.wiki.org\nh2.ward.asia.wiki.org\n\nHappening #2\n\naudrey.sf.fedwikihappening.net\nanderhaff.ny2.fedwikihappening.net\ncards.aribadernatal.com\nniallb.uk2.fedwikihappening.net\nfrances.uk2.fedwikihappening.net\ncj13.sf2.fedwikihappening.net\nphb256.ny2.fedwikihappening.net\nfortyfoxes.uk2.fedwikihappening.net\ntmtm.uk2.fedwikihappening.net\nkate.au.fedwikihappening.net\ndancallahan.ny2.fedwikihappening.net\ngardnercampbell.ny2.fedwikihappening.net\nchamboonline.sf2.fedwikihappening.net\ntimothyfcook.ny2.fedwikihappening.net\nh2.ward.asia.wiki.org\nadamldavis.ny2.fedwikihappening.net\ntdeflitch.ny2.fedwikihappening.net\npodehaye.uk2.fedwikihappening.net\njrdingwall.sf2.fedwikihappening.net\nkimeke.ny2.fedwikihappening.net\ntelliowkuwp.ny2.fedwikihappening.net\nerbfarm.ny2.fedwikihappening.net\nadrianoferrari.ny2.fedwikihappening.net\nhypervisible.ny2.fedwikihappening.net\ndongorges.ny2.fedwikihappening.net\nelectricarchaeo.ny2.fedwikihappening.net\nfgraver.uk2.fedwikihappening.net\ndaveh70.ny2.fedwikihappening.net\nkwhamon.ny2.fedwikihappening.net\nchaugen.sf2.fedwikihappening.net\ncamhock.ny2.fedwikihappening.net\ndogtrax.ny2.fedwikihappening.net\ntuttlesvc.ny2.fedwikihappening.net\ndonalholland.ny2.fedwikihappening.net\nsarah.uk.fedwikihappening.net\nhwangmoretime.sf2.fedwikihappening.net\nmachines.alyson.sf.fedwikihappening.net\ntheotherjeff.sf2.fedwikihappening.net\ngeonz.ny2.fedwikihappening.net\nfedwiki.djon.es\ntomaskafka.uk2.fedwikihappening.net\nthoka.uk2.fedwikihappening.net\nnick.uk.fedwikihappening.net\ncjunekim.sf2.fedwikihappening.net\ntim.au.fedwikihappening.net\nnlafferty.uk2.fedwikihappening.net\ncogdoghappening.sf2.fedwikihappening.net\nmartinlindner.uk2.fedwikihappening.net\njenny.uk.fedwikihappening.net\nannalisamanca.uk2.fedwikihappening.net\nx28de.uk2.fedwikihappening.net\nSbethm.sf2.fedwikihappening.net\nmcmorgan.ny2.fedwikihappening.net\nbrackenm.ny2.fedwikihappening.net\ncicatriz.ny2.fedwikihappening.net\nottonomy.sf2.fedwikihappening.net\njupidu.uk2.fedwikihappening.net\n14prinsp.ny2.fedwikihappening.net\nreimerth.uk2.fedwikihappening.net\nwiki.allmende.io\nemily.edfedwiki.com\nfedwiki.jeffist.com\npatchcr.ny2.fedwikihappening.net\nfedwiki.jakesandlund.com\nmshook.ny2.fedwikihappening.net"
-  }
-]
+    {
+      "type": "paragraph",
+      "id": "7764988b30d81458",
+      "text": "This plugin provides a hoverable, clickable roster of sites participating in a group activity. [https://github.com/fedwiki/wiki-plugin-roster github]"
     },
-    "date": 1423584302000,
-    "certificate": "from mkplugin.sh"
-  }
-]
+    {
+      "type": "roster",
+      "id": "1eae75c847715275",
+      "text": "Mike Caulfield\n\nmachines.hapgood.net\norientation.hapgood.net\n\nWard Cunningham\n\nward.fed.wiki.org\nward.asia.wiki.org\nforage.ward.fed.wiki.org\nh2.ward.asia.wiki.org\n\nHappening #2\n\nanderhaff.ny2.fedwikihappening.net\nniallb.uk2.fedwikihappening.net\nfrances.uk2.fedwikihappening.net\ncj13.sf2.fedwikihappening.net\nphb256.ny2.fedwikihappening.net\nfortyfoxes.uk2.fedwikihappening.net\ntmtm.uk2.fedwikihappening.net\nkate.au.fedwikihappening.net\ndancallahan.ny2.fedwikihappening.net\ngardnercampbell.ny2.fedwikihappening.net\nchamboonline.sf2.fedwikihappening.net\ntimothyfcook.ny2.fedwikihappening.net\nadamldavis.ny2.fedwikihappening.net\ntdeflitch.ny2.fedwikihappening.net\njrdingwall.sf2.fedwikihappening.net\nkimeke.ny2.fedwikihappening.net\ntelliowkuwp.ny2.fedwikihappening.net\nerbfarm.ny2.fedwikihappening.net\nadrianoferrari.ny2.fedwikihappening.net\nhypervisible.ny2.fedwikihappening.net\ndongorges.ny2.fedwikihappening.net\nelectricarchaeo.ny2.fedwikihappening.net\nfgraver.uk2.fedwikihappening.net\ndaveh70.ny2.fedwikihappening.net\nkwhamon.ny2.fedwikihappening.net\nchaugen.sf2.fedwikihappening.net\ncamhock.ny2.fedwikihappening.net\ndogtrax.ny2.fedwikihappening.net\ntuttlesvc.ny2.fedwikihappening.net\ndonalholland.ny2.fedwikihappening.net\nsarah.uk.fedwikihappening.net\nhwangmoretime.sf2.fedwikihappening.net\nmachines.alyson.sf.fedwikihappening.net\ntheotherjeff.sf2.fedwikihappening.net\ngeonz.ny2.fedwikihappening.net\ntomaskafka.uk2.fedwikihappening.net\ncjunekim.sf2.fedwikihappening.net\nnlafferty.uk2.fedwikihappening.net\ncogdoghappening.sf2.fedwikihappening.net\nmartinlindner.uk2.fedwikihappening.net\nannalisamanca.uk2.fedwikihappening.net\nx28de.uk2.fedwikihappening.net\nSbethm.sf2.fedwikihappening.net\nmcmorgan.ny2.fedwikihappening.net\nbrackenm.ny2.fedwikihappening.net\ncicatriz.ny2.fedwikihappening.net\nottonomy.sf2.fedwikihappening.net\njupidu.uk2.fedwikihappening.net\n14prinsp.ny2.fedwikihappening.net\nreimerth.uk2.fedwikihappening.net\npatchcr.ny2.fedwikihappening.net\nmshook.ny2.fedwikihappening.net"
+    },
+    {
+      "type": "paragraph",
+      "id": "9c74b009fb447d11",
+      "text": "Sites show as their flags. Click to open the site's welcome page. Hover to read its domain name."
+    },
+    {
+      "type": "paragraph",
+      "id": "7a5d9186220eddf9",
+      "text": "Add multiple sites to the neighborhood by clicking the » that follow each row."
+    },
+    {
+      "type": "markdown",
+      "id": "194c498a4d2d32d5",
+      "text": "# Markup"
+    },
+    {
+      "type": "paragraph",
+      "id": "872640cf65c6044a",
+      "text": "Write site domain names, one per line, to add them to the roster and show their flags on the page."
+    },
+    {
+      "type": "code",
+      "id": "156e759f191db120",
+      "text": "ward.wiki.example.com\nmike.wiki.example.com"
+    },
+    {
+      "type": "paragraph",
+      "id": "39a54510267cc2ef",
+      "text": "Some lines have special meaning."
+    },
+    {
+      "type": "paragraph",
+      "id": "6abe048a024cdcdd",
+      "text": "A blank line will start a new line in the roster."
+    },
+    {
+      "type": "paragraph",
+      "id": "df0232abf4b21d37",
+      "text": "Include a roster from a remote site with an INCLUDE line specifying the site/slug for a page containing another Roster plugin who's lines replace the include."
+    },
+    {
+      "type": "code",
+      "id": "018e331b78806fa5",
+      "text": "INCLUDE ward.wiki.example.com/late-class-arrivals"
+    },
+    {
+      "type": "paragraph",
+      "id": "ce8b438d9cb71558",
+      "text": "Any other lines will label categories within which the subsequent sites will be placed. These categories become available to other plugins."
+    },
+    {
+      "type": "code",
+      "id": "c08267d3567a08c5",
+      "text": "Happening #2"
+    },
+    {
+      "type": "paragraph",
+      "id": "fc6c3252b5da107a",
+      "text": "See [[About Activity Plugin]] for possible uses."
+    }
+  ],
+  "journal": [
+    {
+      "type": "create",
+      "item": {
+        "title": "About Roster Plugin",
+        "story": [
+          {
+            "type": "paragraph",
+            "id": "7764988b30d81458",
+            "text": "This plugin provides a hoverable, clickable roster of sites participating in a group activity."
+          },
+          {
+            "type": "roster",
+            "id": "1eae75c847715275",
+            "text": "Mike Caulfield\n\nmachines.hapgood.net\norientation.hapgood.net\n\nWard Cunningham\n\nward.fed.wiki.org\nward.asia.wiki.org\nforage.ward.fed.wiki.org\nh2.ward.asia.wiki.org\n\nHappening #2\n\naudrey.sf.fedwikihappening.net\nanderhaff.ny2.fedwikihappening.net\ncards.aribadernatal.com\nniallb.uk2.fedwikihappening.net\nfrances.uk2.fedwikihappening.net\ncj13.sf2.fedwikihappening.net\nphb256.ny2.fedwikihappening.net\nfortyfoxes.uk2.fedwikihappening.net\ntmtm.uk2.fedwikihappening.net\nkate.au.fedwikihappening.net\ndancallahan.ny2.fedwikihappening.net\ngardnercampbell.ny2.fedwikihappening.net\nchamboonline.sf2.fedwikihappening.net\ntimothyfcook.ny2.fedwikihappening.net\nh2.ward.asia.wiki.org\nadamldavis.ny2.fedwikihappening.net\ntdeflitch.ny2.fedwikihappening.net\npodehaye.uk2.fedwikihappening.net\njrdingwall.sf2.fedwikihappening.net\nkimeke.ny2.fedwikihappening.net\ntelliowkuwp.ny2.fedwikihappening.net\nerbfarm.ny2.fedwikihappening.net\nadrianoferrari.ny2.fedwikihappening.net\nhypervisible.ny2.fedwikihappening.net\ndongorges.ny2.fedwikihappening.net\nelectricarchaeo.ny2.fedwikihappening.net\nfgraver.uk2.fedwikihappening.net\ndaveh70.ny2.fedwikihappening.net\nkwhamon.ny2.fedwikihappening.net\nchaugen.sf2.fedwikihappening.net\ncamhock.ny2.fedwikihappening.net\ndogtrax.ny2.fedwikihappening.net\ntuttlesvc.ny2.fedwikihappening.net\ndonalholland.ny2.fedwikihappening.net\nsarah.uk.fedwikihappening.net\nhwangmoretime.sf2.fedwikihappening.net\nmachines.alyson.sf.fedwikihappening.net\ntheotherjeff.sf2.fedwikihappening.net\ngeonz.ny2.fedwikihappening.net\nfedwiki.djon.es\ntomaskafka.uk2.fedwikihappening.net\nthoka.uk2.fedwikihappening.net\nnick.uk.fedwikihappening.net\ncjunekim.sf2.fedwikihappening.net\ntim.au.fedwikihappening.net\nnlafferty.uk2.fedwikihappening.net\ncogdoghappening.sf2.fedwikihappening.net\nmartinlindner.uk2.fedwikihappening.net\njenny.uk.fedwikihappening.net\nannalisamanca.uk2.fedwikihappening.net\nx28de.uk2.fedwikihappening.net\nSbethm.sf2.fedwikihappening.net\nmcmorgan.ny2.fedwikihappening.net\nbrackenm.ny2.fedwikihappening.net\ncicatriz.ny2.fedwikihappening.net\nottonomy.sf2.fedwikihappening.net\njupidu.uk2.fedwikihappening.net\n14prinsp.ny2.fedwikihappening.net\nreimerth.uk2.fedwikihappening.net\nwiki.allmende.io\nemily.edfedwiki.com\nfedwiki.jeffist.com\npatchcr.ny2.fedwikihappening.net\nfedwiki.jakesandlund.com\nmshook.ny2.fedwikihappening.net"
+          }
+        ]
+      },
+      "date": 1423584302000,
+      "certificate": "from mkplugin.sh"
+    },
+    {
+      "type": "edit",
+      "id": "1eae75c847715275",
+      "item": {
+        "type": "roster",
+        "id": "1eae75c847715275",
+        "text": "Mike Caulfield\n\nmachines.hapgood.net\norientation.hapgood.net\n\nWard Cunningham\n\nward.fed.wiki.org\nward.asia.wiki.org\nforage.ward.fed.wiki.org\nh2.ward.asia.wiki.org\n\nHappening #2\n\nanderhaff.ny2.fedwikihappening.net\ncards.aribadernatal.com\nniallb.uk2.fedwikihappening.net\nfrances.uk2.fedwikihappening.net\ncj13.sf2.fedwikihappening.net\nphb256.ny2.fedwikihappening.net\nfortyfoxes.uk2.fedwikihappening.net\ntmtm.uk2.fedwikihappening.net\nkate.au.fedwikihappening.net\ndancallahan.ny2.fedwikihappening.net\ngardnercampbell.ny2.fedwikihappening.net\nchamboonline.sf2.fedwikihappening.net\ntimothyfcook.ny2.fedwikihappening.net\nh2.ward.asia.wiki.org\nadamldavis.ny2.fedwikihappening.net\ntdeflitch.ny2.fedwikihappening.net\njrdingwall.sf2.fedwikihappening.net\nkimeke.ny2.fedwikihappening.net\ntelliowkuwp.ny2.fedwikihappening.net\nerbfarm.ny2.fedwikihappening.net\nadrianoferrari.ny2.fedwikihappening.net\nhypervisible.ny2.fedwikihappening.net\ndongorges.ny2.fedwikihappening.net\nelectricarchaeo.ny2.fedwikihappening.net\nfgraver.uk2.fedwikihappening.net\ndaveh70.ny2.fedwikihappening.net\nkwhamon.ny2.fedwikihappening.net\nchaugen.sf2.fedwikihappening.net\ncamhock.ny2.fedwikihappening.net\ndogtrax.ny2.fedwikihappening.net\ntuttlesvc.ny2.fedwikihappening.net\ndonalholland.ny2.fedwikihappening.net\nsarah.uk.fedwikihappening.net\nhwangmoretime.sf2.fedwikihappening.net\nmachines.alyson.sf.fedwikihappening.net\ntheotherjeff.sf2.fedwikihappening.net\ngeonz.ny2.fedwikihappening.net\nfedwiki.djon.es\ntomaskafka.uk2.fedwikihappening.net\nthoka.uk2.fedwikihappening.net\nnick.uk.fedwikihappening.net\ncjunekim.sf2.fedwikihappening.net\ntim.au.fedwikihappening.net\nnlafferty.uk2.fedwikihappening.net\ncogdoghappening.sf2.fedwikihappening.net\nmartinlindner.uk2.fedwikihappening.net\njenny.uk.fedwikihappening.net\nannalisamanca.uk2.fedwikihappening.net\nx28de.uk2.fedwikihappening.net\nSbethm.sf2.fedwikihappening.net\nmcmorgan.ny2.fedwikihappening.net\nbrackenm.ny2.fedwikihappening.net\ncicatriz.ny2.fedwikihappening.net\nottonomy.sf2.fedwikihappening.net\njupidu.uk2.fedwikihappening.net\n14prinsp.ny2.fedwikihappening.net\nreimerth.uk2.fedwikihappening.net\nwiki.allmende.io\nemily.edfedwiki.com\nfedwiki.jeffist.com\npatchcr.ny2.fedwikihappening.net\nfedwiki.jakesandlund.com\nmshook.ny2.fedwikihappening.net"
+      },
+      "date": 1432960364697
+    },
+    {
+      "type": "edit",
+      "id": "1eae75c847715275",
+      "item": {
+        "type": "roster",
+        "id": "1eae75c847715275",
+        "text": "Mike Caulfield\n\nmachines.hapgood.net\norientation.hapgood.net\n\nWard Cunningham\n\nward.fed.wiki.org\nward.asia.wiki.org\nforage.ward.fed.wiki.org\nh2.ward.asia.wiki.org\n\nHappening #2\n\nanderhaff.ny2.fedwikihappening.net\ncards.aribadernatal.com\nniallb.uk2.fedwikihappening.net\nfrances.uk2.fedwikihappening.net\ncj13.sf2.fedwikihappening.net\nphb256.ny2.fedwikihappening.net\nfortyfoxes.uk2.fedwikihappening.net\ntmtm.uk2.fedwikihappening.net\nkate.au.fedwikihappening.net\ndancallahan.ny2.fedwikihappening.net\ngardnercampbell.ny2.fedwikihappening.net\nchamboonline.sf2.fedwikihappening.net\ntimothyfcook.ny2.fedwikihappening.net\nh2.ward.asia.wiki.org\nadamldavis.ny2.fedwikihappening.net\ntdeflitch.ny2.fedwikihappening.net\njrdingwall.sf2.fedwikihappening.net\nkimeke.ny2.fedwikihappening.net\ntelliowkuwp.ny2.fedwikihappening.net\nerbfarm.ny2.fedwikihappening.net\nadrianoferrari.ny2.fedwikihappening.net\nhypervisible.ny2.fedwikihappening.net\ndongorges.ny2.fedwikihappening.net\nelectricarchaeo.ny2.fedwikihappening.net\nfgraver.uk2.fedwikihappening.net\ndaveh70.ny2.fedwikihappening.net\nkwhamon.ny2.fedwikihappening.net\nchaugen.sf2.fedwikihappening.net\ncamhock.ny2.fedwikihappening.net\ndogtrax.ny2.fedwikihappening.net\ntuttlesvc.ny2.fedwikihappening.net\ndonalholland.ny2.fedwikihappening.net\nsarah.uk.fedwikihappening.net\nhwangmoretime.sf2.fedwikihappening.net\nmachines.alyson.sf.fedwikihappening.net\ntheotherjeff.sf2.fedwikihappening.net\ngeonz.ny2.fedwikihappening.net\ntomaskafka.uk2.fedwikihappening.net\nthoka.uk2.fedwikihappening.net\nnick.uk.fedwikihappening.net\ncjunekim.sf2.fedwikihappening.net\ntim.au.fedwikihappening.net\nnlafferty.uk2.fedwikihappening.net\ncogdoghappening.sf2.fedwikihappening.net\nmartinlindner.uk2.fedwikihappening.net\njenny.uk.fedwikihappening.net\nannalisamanca.uk2.fedwikihappening.net\nx28de.uk2.fedwikihappening.net\nSbethm.sf2.fedwikihappening.net\nmcmorgan.ny2.fedwikihappening.net\nbrackenm.ny2.fedwikihappening.net\ncicatriz.ny2.fedwikihappening.net\nottonomy.sf2.fedwikihappening.net\njupidu.uk2.fedwikihappening.net\n14prinsp.ny2.fedwikihappening.net\nreimerth.uk2.fedwikihappening.net\nwiki.allmende.io\nemily.edfedwiki.com\nfedwiki.jeffist.com\npatchcr.ny2.fedwikihappening.net\nfedwiki.jakesandlund.com\nmshook.ny2.fedwikihappening.net"
+      },
+      "date": 1432960399804
+    },
+    {
+      "type": "edit",
+      "id": "1eae75c847715275",
+      "item": {
+        "type": "roster",
+        "id": "1eae75c847715275",
+        "text": "Mike Caulfield\n\nmachines.hapgood.net\norientation.hapgood.net\n\nWard Cunningham\n\nward.fed.wiki.org\nward.asia.wiki.org\nforage.ward.fed.wiki.org\nh2.ward.asia.wiki.org\n\nHappening #2\n\nanderhaff.ny2.fedwikihappening.net\ncards.aribadernatal.com\nniallb.uk2.fedwikihappening.net\nfrances.uk2.fedwikihappening.net\ncj13.sf2.fedwikihappening.net\nphb256.ny2.fedwikihappening.net\nfortyfoxes.uk2.fedwikihappening.net\ntmtm.uk2.fedwikihappening.net\nkate.au.fedwikihappening.net\ndancallahan.ny2.fedwikihappening.net\ngardnercampbell.ny2.fedwikihappening.net\nchamboonline.sf2.fedwikihappening.net\ntimothyfcook.ny2.fedwikihappening.net\nh2.ward.asia.wiki.org\nadamldavis.ny2.fedwikihappening.net\ntdeflitch.ny2.fedwikihappening.net\njrdingwall.sf2.fedwikihappening.net\nkimeke.ny2.fedwikihappening.net\ntelliowkuwp.ny2.fedwikihappening.net\nerbfarm.ny2.fedwikihappening.net\nadrianoferrari.ny2.fedwikihappening.net\nhypervisible.ny2.fedwikihappening.net\ndongorges.ny2.fedwikihappening.net\nelectricarchaeo.ny2.fedwikihappening.net\nfgraver.uk2.fedwikihappening.net\ndaveh70.ny2.fedwikihappening.net\nkwhamon.ny2.fedwikihappening.net\nchaugen.sf2.fedwikihappening.net\ncamhock.ny2.fedwikihappening.net\ndogtrax.ny2.fedwikihappening.net\ntuttlesvc.ny2.fedwikihappening.net\ndonalholland.ny2.fedwikihappening.net\nsarah.uk.fedwikihappening.net\nhwangmoretime.sf2.fedwikihappening.net\nmachines.alyson.sf.fedwikihappening.net\ntheotherjeff.sf2.fedwikihappening.net\ngeonz.ny2.fedwikihappening.net\ntomaskafka.uk2.fedwikihappening.net\ncjunekim.sf2.fedwikihappening.net\nnlafferty.uk2.fedwikihappening.net\ncogdoghappening.sf2.fedwikihappening.net\nmartinlindner.uk2.fedwikihappening.net\njenny.uk.fedwikihappening.net\nannalisamanca.uk2.fedwikihappening.net\nx28de.uk2.fedwikihappening.net\nSbethm.sf2.fedwikihappening.net\nmcmorgan.ny2.fedwikihappening.net\nbrackenm.ny2.fedwikihappening.net\ncicatriz.ny2.fedwikihappening.net\nottonomy.sf2.fedwikihappening.net\njupidu.uk2.fedwikihappening.net\n14prinsp.ny2.fedwikihappening.net\nreimerth.uk2.fedwikihappening.net\nwiki.allmende.io\nemily.edfedwiki.com\nfedwiki.jeffist.com\npatchcr.ny2.fedwikihappening.net\nmshook.ny2.fedwikihappening.net"
+      },
+      "date": 1432960445615
+    },
+    {
+      "type": "edit",
+      "id": "1eae75c847715275",
+      "item": {
+        "type": "roster",
+        "id": "1eae75c847715275",
+        "text": "Mike Caulfield\n\nmachines.hapgood.net\norientation.hapgood.net\n\nWard Cunningham\n\nward.fed.wiki.org\nward.asia.wiki.org\nforage.ward.fed.wiki.org\nh2.ward.asia.wiki.org\n\nHappening #2\n\nanderhaff.ny2.fedwikihappening.net\nniallb.uk2.fedwikihappening.net\nfrances.uk2.fedwikihappening.net\ncj13.sf2.fedwikihappening.net\nphb256.ny2.fedwikihappening.net\nfortyfoxes.uk2.fedwikihappening.net\ntmtm.uk2.fedwikihappening.net\nkate.au.fedwikihappening.net\ndancallahan.ny2.fedwikihappening.net\ngardnercampbell.ny2.fedwikihappening.net\nchamboonline.sf2.fedwikihappening.net\ntimothyfcook.ny2.fedwikihappening.net\nadamldavis.ny2.fedwikihappening.net\ntdeflitch.ny2.fedwikihappening.net\njrdingwall.sf2.fedwikihappening.net\nkimeke.ny2.fedwikihappening.net\ntelliowkuwp.ny2.fedwikihappening.net\nerbfarm.ny2.fedwikihappening.net\nadrianoferrari.ny2.fedwikihappening.net\nhypervisible.ny2.fedwikihappening.net\ndongorges.ny2.fedwikihappening.net\nelectricarchaeo.ny2.fedwikihappening.net\nfgraver.uk2.fedwikihappening.net\ndaveh70.ny2.fedwikihappening.net\nkwhamon.ny2.fedwikihappening.net\nchaugen.sf2.fedwikihappening.net\ncamhock.ny2.fedwikihappening.net\ndogtrax.ny2.fedwikihappening.net\ntuttlesvc.ny2.fedwikihappening.net\ndonalholland.ny2.fedwikihappening.net\nsarah.uk.fedwikihappening.net\nhwangmoretime.sf2.fedwikihappening.net\nmachines.alyson.sf.fedwikihappening.net\ntheotherjeff.sf2.fedwikihappening.net\ngeonz.ny2.fedwikihappening.net\ntomaskafka.uk2.fedwikihappening.net\ncjunekim.sf2.fedwikihappening.net\nnlafferty.uk2.fedwikihappening.net\ncogdoghappening.sf2.fedwikihappening.net\nmartinlindner.uk2.fedwikihappening.net\nannalisamanca.uk2.fedwikihappening.net\nx28de.uk2.fedwikihappening.net\nSbethm.sf2.fedwikihappening.net\nmcmorgan.ny2.fedwikihappening.net\nbrackenm.ny2.fedwikihappening.net\ncicatriz.ny2.fedwikihappening.net\nottonomy.sf2.fedwikihappening.net\njupidu.uk2.fedwikihappening.net\n14prinsp.ny2.fedwikihappening.net\nreimerth.uk2.fedwikihappening.net\npatchcr.ny2.fedwikihappening.net\nmshook.ny2.fedwikihappening.net"
+      },
+      "date": 1432960542087
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "872640cf65c6044a"
+      },
+      "id": "872640cf65c6044a",
+      "type": "add",
+      "after": "1eae75c847715275",
+      "date": 1432960598580
+    },
+    {
+      "type": "edit",
+      "id": "872640cf65c6044a",
+      "item": {
+        "type": "paragraph",
+        "id": "872640cf65c6044a",
+        "text": "Use site domain names as the markup for a roster, one per line. The plugin will fetch the flag for each of these sites."
+      },
+      "date": 1432960851489
+    },
+    {
+      "type": "edit",
+      "id": "872640cf65c6044a",
+      "item": {
+        "type": "paragraph",
+        "id": "872640cf65c6044a",
+        "text": "Use site domain names as the markup for a roster, one per line. Sites show as clickable flags. Hover to read the domain name."
+      },
+      "date": 1432960917299
+    },
+    {
+      "type": "edit",
+      "id": "872640cf65c6044a",
+      "item": {
+        "type": "paragraph",
+        "id": "872640cf65c6044a",
+        "text": "Use site domain names as the markup for a roster, one per line. Sites show as clickable flags. Click to open the welcome page for a site. Hover to read the domain name."
+      },
+      "date": 1432960946645
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "156e759f191db120"
+      },
+      "id": "156e759f191db120",
+      "type": "add",
+      "after": "872640cf65c6044a",
+      "date": 1432960949730
+    },
+    {
+      "type": "edit",
+      "id": "156e759f191db120",
+      "item": {
+        "type": "code",
+        "id": "156e759f191db120",
+        "text": "ward.wiki.example.com\nmike.wiki.example.com"
+      },
+      "date": 1432960974251
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "39a54510267cc2ef"
+      },
+      "id": "39a54510267cc2ef",
+      "type": "add",
+      "after": "156e759f191db120",
+      "date": 1432960990386
+    },
+    {
+      "type": "edit",
+      "id": "39a54510267cc2ef",
+      "item": {
+        "type": "paragraph",
+        "id": "39a54510267cc2ef",
+        "text": "Some lines have special meaning."
+      },
+      "date": 1432961012366
+    },
+    {
+      "type": "add",
+      "id": "6abe048a024cdcdd",
+      "item": {
+        "type": "paragraph",
+        "id": "6abe048a024cdcdd",
+        "text": "A blank line will start a new line in the roster."
+      },
+      "after": "39a54510267cc2ef",
+      "date": 1432961041691
+    },
+    {
+      "type": "add",
+      "id": "df0232abf4b21d37",
+      "item": {
+        "type": "paragraph",
+        "id": "df0232abf4b21d37",
+        "text": "Say "
+      },
+      "after": "6abe048a024cdcdd",
+      "date": 1432961059092
+    },
+    {
+      "type": "edit",
+      "id": "df0232abf4b21d37",
+      "item": {
+        "type": "paragraph",
+        "id": "df0232abf4b21d37",
+        "text": "Include a roster from a remote site with an INCLUDE line specifying the site/slug for the site."
+      },
+      "date": 1432961191659
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "018e331b78806fa5"
+      },
+      "id": "018e331b78806fa5",
+      "type": "add",
+      "after": "df0232abf4b21d37",
+      "date": 1432961196373
+    },
+    {
+      "type": "edit",
+      "id": "018e331b78806fa5",
+      "item": {
+        "type": "code",
+        "id": "018e331b78806fa5",
+        "text": "INCLUDE ward.wiki.example.com/late-class-arrivals"
+      },
+      "date": 1432961245980
+    },
+    {
+      "type": "edit",
+      "id": "df0232abf4b21d37",
+      "item": {
+        "type": "paragraph",
+        "id": "df0232abf4b21d37",
+        "text": "Include a roster from a remote site with an INCLUDE line specifying the site/slug for a page containing another Roster."
+      },
+      "date": 1432961296097
+    },
+    {
+      "type": "edit",
+      "id": "7764988b30d81458",
+      "item": {
+        "type": "paragraph",
+        "id": "7764988b30d81458",
+        "text": "This plugin provides a hoverable, clickable roster of sites participating in a group activity. [https://github.com/fedwiki/wiki-plugin-roster github]"
+      },
+      "date": 1432961759512
+    },
+    {
+      "type": "edit",
+      "id": "df0232abf4b21d37",
+      "item": {
+        "type": "paragraph",
+        "id": "df0232abf4b21d37",
+        "text": "Include a roster from a remote site with an INCLUDE line specifying the site/slug for a page containing another Roster who's lines replace the include."
+      },
+      "date": 1432964040805
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "ce8b438d9cb71558"
+      },
+      "id": "ce8b438d9cb71558",
+      "type": "add",
+      "after": "018e331b78806fa5",
+      "date": 1432964080050
+    },
+    {
+      "type": "edit",
+      "id": "ce8b438d9cb71558",
+      "item": {
+        "type": "paragraph",
+        "id": "ce8b438d9cb71558",
+        "text": "Any other lines will label categories of sites. See [[About Activity Plugin]]"
+      },
+      "date": 1432964168547
+    },
+    {
+      "type": "edit",
+      "id": "ce8b438d9cb71558",
+      "item": {
+        "type": "paragraph",
+        "id": "ce8b438d9cb71558",
+        "text": "Any other lines will label categories within which the subsequent sites will be placed. These categories become available to other plugins. See [[About Activity Plugin]] "
+      },
+      "date": 1432964277843
+    },
+    {
+      "type": "edit",
+      "id": "872640cf65c6044a",
+      "item": {
+        "type": "paragraph",
+        "id": "872640cf65c6044a",
+        "text": "Use site domain names as the markup for a roster, one per line."
+      },
+      "date": 1432965315481
+    },
+    {
+      "type": "add",
+      "id": "9c74b009fb447d11",
+      "item": {
+        "type": "paragraph",
+        "id": "9c74b009fb447d11",
+        "text": "Sites show as clickable flags. Click to open the welcome page for a site. Hover to read the domain name."
+      },
+      "after": "7764988b30d81458",
+      "date": 1432965323389
+    },
+    {
+      "type": "edit",
+      "id": "9c74b009fb447d11",
+      "item": {
+        "type": "paragraph",
+        "id": "9c74b009fb447d11",
+        "text": "Sites show as their flags. Click to open the site's welcome page. Hover to read its domain name."
+      },
+      "date": 1432965435071
+    },
+    {
+      "type": "add",
+      "id": "7a5d9186220eddf9",
+      "item": {
+        "type": "paragraph",
+        "id": "7a5d9186220eddf9",
+        "text": "All sites from each row can be added to the neighborhood without opening any pages. Click the "
+      },
+      "after": "9c74b009fb447d11",
+      "date": 1432965533764
+    },
+    {
+      "type": "edit",
+      "id": "7a5d9186220eddf9",
+      "item": {
+        "type": "paragraph",
+        "id": "7a5d9186220eddf9",
+        "text": "All sites from each row can be added to the neighborhood without opening any pages by clicking the » that follows each row."
+      },
+      "date": 1432965606354
+    },
+    {
+      "type": "edit",
+      "id": "7a5d9186220eddf9",
+      "item": {
+        "type": "paragraph",
+        "id": "7a5d9186220eddf9",
+        "text": "Add multiple sites to the neighborhood by clicking the » that follows each row."
+      },
+      "date": 1432965659589
+    },
+    {
+      "type": "edit",
+      "id": "7a5d9186220eddf9",
+      "item": {
+        "type": "paragraph",
+        "id": "7a5d9186220eddf9",
+        "text": "Add multiple sites to the neighborhood by clicking the » that follow each row."
+      },
+      "date": 1432965683055
+    },
+    {
+      "type": "move",
+      "order": [
+        "7764988b30d81458",
+        "1eae75c847715275",
+        "9c74b009fb447d11",
+        "7a5d9186220eddf9",
+        "872640cf65c6044a",
+        "156e759f191db120",
+        "39a54510267cc2ef",
+        "6abe048a024cdcdd",
+        "df0232abf4b21d37",
+        "018e331b78806fa5",
+        "ce8b438d9cb71558"
+      ],
+      "id": "1eae75c847715275",
+      "date": 1432965696474
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "194c498a4d2d32d5"
+      },
+      "id": "194c498a4d2d32d5",
+      "type": "add",
+      "after": "ce8b438d9cb71558",
+      "date": 1432965703411
+    },
+    {
+      "type": "edit",
+      "id": "194c498a4d2d32d5",
+      "item": {
+        "type": "markdown",
+        "id": "194c498a4d2d32d5",
+        "text": "# Markup"
+      },
+      "date": 1432965712559
+    },
+    {
+      "type": "move",
+      "order": [
+        "7764988b30d81458",
+        "1eae75c847715275",
+        "9c74b009fb447d11",
+        "7a5d9186220eddf9",
+        "194c498a4d2d32d5",
+        "872640cf65c6044a",
+        "156e759f191db120",
+        "39a54510267cc2ef",
+        "6abe048a024cdcdd",
+        "df0232abf4b21d37",
+        "018e331b78806fa5",
+        "ce8b438d9cb71558"
+      ],
+      "id": "194c498a4d2d32d5",
+      "date": 1432965718097
+    },
+    {
+      "type": "edit",
+      "id": "872640cf65c6044a",
+      "item": {
+        "type": "paragraph",
+        "id": "872640cf65c6044a",
+        "text": "Write site domain names, one per line, to add them to the roster and show their flags on the page."
+      },
+      "date": 1432965905168
+    },
+    {
+      "type": "edit",
+      "id": "df0232abf4b21d37",
+      "item": {
+        "type": "paragraph",
+        "id": "df0232abf4b21d37",
+        "text": "Include a roster from a remote site with an INCLUDE line specifying the site/slug for a page containing another Roster plugin who's lines replace the include."
+      },
+      "date": 1432965999520
+    },
+    {
+      "type": "edit",
+      "id": "ce8b438d9cb71558",
+      "item": {
+        "type": "paragraph",
+        "id": "ce8b438d9cb71558",
+        "text": "Any other lines will label categories within which the subsequent sites will be placed. These categories become available to other plugins."
+      },
+      "date": 1432966073006
+    },
+    {
+      "type": "add",
+      "id": "fc6c3252b5da107a",
+      "item": {
+        "type": "paragraph",
+        "id": "fc6c3252b5da107a",
+        "text": "See [[About Activity Plugin]] "
+      },
+      "after": "ce8b438d9cb71558",
+      "date": 1432966074445
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "c08267d3567a08c5"
+      },
+      "id": "c08267d3567a08c5",
+      "type": "add",
+      "after": "fc6c3252b5da107a",
+      "date": 1432966078900
+    },
+    {
+      "type": "edit",
+      "id": "c08267d3567a08c5",
+      "item": {
+        "type": "code",
+        "id": "c08267d3567a08c5",
+        "text": "Happening #2"
+      },
+      "date": 1432966087932
+    },
+    {
+      "type": "move",
+      "order": [
+        "7764988b30d81458",
+        "1eae75c847715275",
+        "9c74b009fb447d11",
+        "7a5d9186220eddf9",
+        "194c498a4d2d32d5",
+        "872640cf65c6044a",
+        "156e759f191db120",
+        "39a54510267cc2ef",
+        "6abe048a024cdcdd",
+        "df0232abf4b21d37",
+        "018e331b78806fa5",
+        "ce8b438d9cb71558",
+        "c08267d3567a08c5",
+        "fc6c3252b5da107a"
+      ],
+      "id": "c08267d3567a08c5",
+      "date": 1432966091219
+    },
+    {
+      "type": "edit",
+      "id": "fc6c3252b5da107a",
+      "item": {
+        "type": "paragraph",
+        "id": "fc6c3252b5da107a",
+        "text": "See [[About Activity Plugin]] for possible uses."
+      },
+      "date": 1432966111079
+    }
+  ]
 }

--- a/pages/about-roster-plugin
+++ b/pages/about-roster-plugin
@@ -44,17 +44,17 @@
     {
       "type": "paragraph",
       "id": "6abe048a024cdcdd",
-      "text": "A blank line will start a new line in the roster."
+      "text": "A blank markup line will start a new line in the roster."
     },
     {
       "type": "paragraph",
       "id": "df0232abf4b21d37",
-      "text": "Include a roster from a remote site with an INCLUDE line specifying the site/slug for a page containing another Roster plugin who's lines replace the include."
+      "text": "Include sites from a remote page with a ROSTER or REFERENCES line specifying the site/slug for a page containing Reference items or another Roster item with the sites to be included in this Roster."
     },
     {
       "type": "code",
       "id": "018e331b78806fa5",
-      "text": "INCLUDE ward.wiki.example.com/late-class-arrivals"
+      "text": "ROSTER ward.wiki.example.com/late-class-arrivals\nREFERENCES ward.wiki.example.com/late-class-arrivals"
     },
     {
       "type": "paragraph",
@@ -68,8 +68,8 @@
     },
     {
       "type": "paragraph",
-      "id": "fc6c3252b5da107a",
-      "text": "See [[About Activity Plugin]] for possible uses."
+      "id": "8e4ec8c938b86444",
+      "text": "See [[More About Roster Categories]]"
     }
   ],
   "journal": [
@@ -545,6 +545,52 @@
         "text": "See [[About Activity Plugin]] for possible uses."
       },
       "date": 1432966111079
+    },
+    {
+      "type": "edit",
+      "id": "df0232abf4b21d37",
+      "item": {
+        "type": "paragraph",
+        "id": "df0232abf4b21d37",
+        "text": "Include sites from a remote page with a ROSTER or REFERENCES line specifying the site/slug for a page containing Reference items or another Roster item with the sites to be included in this Roster."
+      },
+      "date": 1433104766659
+    },
+    {
+      "type": "edit",
+      "id": "018e331b78806fa5",
+      "item": {
+        "type": "code",
+        "id": "018e331b78806fa5",
+        "text": "ROSTER ward.wiki.example.com/late-class-arrivals\nREFERENCES ward.wiki.example.com/late-class-arrivals"
+      },
+      "date": 1433104801368
+    },
+    {
+      "type": "add",
+      "id": "8e4ec8c938b86444",
+      "item": {
+        "type": "paragraph",
+        "id": "8e4ec8c938b86444",
+        "text": "See [[More About Roster Categories]]"
+      },
+      "after": "fc6c3252b5da107a",
+      "date": 1433104889329
+    },
+    {
+      "type": "remove",
+      "id": "fc6c3252b5da107a",
+      "date": 1433106239317
+    },
+    {
+      "type": "edit",
+      "id": "6abe048a024cdcdd",
+      "item": {
+        "type": "paragraph",
+        "id": "6abe048a024cdcdd",
+        "text": "A blank markup line will start a new line in the roster."
+      },
+      "date": 1433106329900
     }
   ]
 }

--- a/pages/more-about-roster-categories
+++ b/pages/more-about-roster-categories
@@ -1,0 +1,335 @@
+{
+  "title": "More About Roster Categories",
+  "story": [
+    {
+      "type": "paragraph",
+      "id": "6ef5a3efa5295966",
+      "text": "The sites in a Roster can be broken down into categories which are made available to other plugins."
+    },
+    {
+      "type": "paragraph",
+      "id": "0ad4018c829ee9ef",
+      "text": "A blank line of markup starts a new line in the Roster."
+    },
+    {
+      "type": "paragraph",
+      "id": "91d2bfd784f4870d",
+      "text": "Any line of markup that is not recognized as a site or special command can become a category name."
+    },
+    {
+      "type": "paragraph",
+      "id": "f294f7ab878f6cc9",
+      "text": "The category will include all sites on the current and subsequent Roster display lines until another category name is encountered."
+    },
+    {
+      "type": "paragraph",
+      "id": "e4819f02426d8125",
+      "text": "Category names can appear before, after or even between sites on a line. Remember blank lines of markup start new lines in the Roster display."
+    },
+    {
+      "type": "roster",
+      "id": "b069226796619d55",
+      "text": "Ward Cunningham\nward.fed.wiki.org\nward.asia.wiki.org\n\nMike Caulfield\nmachines.hapgood.net\norientation.hapgood.net"
+    },
+    {
+      "type": "roster",
+      "id": "18128a9f15326a78",
+      "text": "ward.fed.wiki.org\nward.asia.wiki.org\nWard Cunningham\n\nmachines.hapgood.net\norientation.hapgood.net\nMike Caulfield"
+    },
+    {
+      "type": "roster",
+      "id": "d6c2f5d665498da5",
+      "text": "ward.fed.wiki.org\nWard Cunningham\nward.asia.wiki.org\n\nmachines.hapgood.net\nMike Caulfield\norientation.hapgood.net"
+    },
+    {
+      "type": "paragraph",
+      "id": "08f4856fe5e131bd",
+      "text": "Uncategorized sites can be included but must appear before any category name."
+    },
+    {
+      "type": "roster",
+      "id": "47acecff23d5ae5a",
+      "text": "ward.fed.wiki.org\nward.asia.wiki.org\n\nMike Caulfield\nmachines.hapgood.net\norientation.hapgood.net"
+    },
+    {
+      "type": "paragraph",
+      "id": "9b26197216e9aafe",
+      "text": "All sites, including uncategorized sites, will be included in the automatically created 'all' category."
+    },
+    {
+      "type": "paragraph",
+      "id": "d5ff937d77df0fd6",
+      "text": "Shift-double-click a Roster to see what categories are made available to other plugins."
+    },
+    {
+      "type": "paragraph",
+      "id": "fc6c3252b5da107a",
+      "text": "See [[About Activity Configuration]] for possible uses."
+    }
+  ],
+  "journal": [
+    {
+      "type": "create",
+      "item": {
+        "title": "More About Roster Categories",
+        "story": []
+      },
+      "date": 1433104894051
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "6ef5a3efa5295966"
+      },
+      "id": "6ef5a3efa5295966",
+      "type": "add",
+      "date": 1433104918735
+    },
+    {
+      "type": "edit",
+      "id": "6ef5a3efa5295966",
+      "item": {
+        "type": "paragraph",
+        "id": "6ef5a3efa5295966",
+        "text": "The sites in a Roster can be broken down into categories which are made available to other plugins."
+      },
+      "date": 1433105029295
+    },
+    {
+      "type": "add",
+      "id": "91d2bfd784f4870d",
+      "item": {
+        "type": "paragraph",
+        "id": "91d2bfd784f4870d",
+        "text": "Any line of markup that is not recognized as a site or special command can become a category name."
+      },
+      "after": "6ef5a3efa5295966",
+      "date": 1433105324733
+    },
+    {
+      "type": "add",
+      "id": "f294f7ab878f6cc9",
+      "item": {
+        "type": "paragraph",
+        "id": "f294f7ab878f6cc9",
+        "text": "The category will include all sites on the current and subsequent Roster display lines until another category name is encountered."
+      },
+      "after": "91d2bfd784f4870d",
+      "date": 1433105374601
+    },
+    {
+      "type": "add",
+      "item": {
+        "type": "roster",
+        "id": "b069226796619d55",
+        "text": "Ward Cunningham\nward.fed.wiki.org\nward.asia.wiki.org\n\nMike Caulfield\nmachines.hapgood.net\norientation.hapgood.net"
+      },
+      "after": "f294f7ab878f6cc9",
+      "id": "b069226796619d55",
+      "date": 1433105463574
+    },
+    {
+      "type": "add",
+      "item": {
+        "type": "roster",
+        "id": "18128a9f15326a78",
+        "text": "ward.fed.wiki.org\nward.asia.wiki.org\nWard Cunningham\n\nmachines.hapgood.net\norientation.hapgood.net\nMike Caulfield"
+      },
+      "after": "b069226796619d55",
+      "id": "18128a9f15326a78",
+      "date": 1433105467711
+    },
+    {
+      "type": "add",
+      "item": {
+        "type": "roster",
+        "id": "d6c2f5d665498da5",
+        "text": "ward.fed.wiki.org\nWard Cunningham\nward.asia.wiki.org\n\nmachines.hapgood.net\nMike Caulfield\norientation.hapgood.net"
+      },
+      "after": "18128a9f15326a78",
+      "id": "d6c2f5d665498da5",
+      "date": 1433105473407
+    },
+    {
+      "type": "add",
+      "item": {
+        "type": "roster",
+        "id": "47acecff23d5ae5a",
+        "text": "ward.fed.wiki.org\nward.asia.wiki.org\n\nMike Caulfield\nmachines.hapgood.net\norientation.hapgood.net"
+      },
+      "after": "d6c2f5d665498da5",
+      "id": "47acecff23d5ae5a",
+      "date": 1433105478061
+    },
+    {
+      "type": "add",
+      "id": "e4819f02426d8125",
+      "item": {
+        "type": "paragraph",
+        "id": "e4819f02426d8125",
+        "text": "Category names can appear before, after or even between sites on a line. Remember blank lines of markup start new lines in the Roster display."
+      },
+      "after": "f294f7ab878f6cc9",
+      "date": 1433105723937
+    },
+    {
+      "type": "add",
+      "id": "08f4856fe5e131bd",
+      "item": {
+        "type": "paragraph",
+        "id": "08f4856fe5e131bd",
+        "text": "Uncategorized sites can be included but must appear before any category name."
+      },
+      "after": "e4819f02426d8125",
+      "date": 1433105783214
+    },
+    {
+      "type": "move",
+      "order": [
+        "6ef5a3efa5295966",
+        "91d2bfd784f4870d",
+        "f294f7ab878f6cc9",
+        "e4819f02426d8125",
+        "b069226796619d55",
+        "18128a9f15326a78",
+        "d6c2f5d665498da5",
+        "08f4856fe5e131bd",
+        "47acecff23d5ae5a"
+      ],
+      "id": "08f4856fe5e131bd",
+      "date": 1433105787216
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "9b26197216e9aafe"
+      },
+      "id": "9b26197216e9aafe",
+      "type": "add",
+      "after": "47acecff23d5ae5a",
+      "date": 1433105798794
+    },
+    {
+      "type": "edit",
+      "id": "9b26197216e9aafe",
+      "item": {
+        "type": "paragraph",
+        "id": "9b26197216e9aafe",
+        "text": "All sites will be included in the 'all' category."
+      },
+      "date": 1433105830948
+    },
+    {
+      "type": "edit",
+      "id": "9b26197216e9aafe",
+      "item": {
+        "type": "paragraph",
+        "id": "9b26197216e9aafe",
+        "text": "All sites, including uncategorized sites, will be included in the 'all' category."
+      },
+      "date": 1433105861521
+    },
+    {
+      "type": "edit",
+      "id": "9b26197216e9aafe",
+      "item": {
+        "type": "paragraph",
+        "id": "9b26197216e9aafe",
+        "text": "All sites, including uncategorized sites, will be included in the 'all' category also made available to other plugins."
+      },
+      "date": 1433105886386
+    },
+    {
+      "type": "edit",
+      "id": "9b26197216e9aafe",
+      "item": {
+        "type": "paragraph",
+        "id": "9b26197216e9aafe",
+        "text": "All sites, including uncategorized sites, will be included in the 'all' category automatically made available to other plugins."
+      },
+      "date": 1433105968094
+    },
+    {
+      "type": "edit",
+      "id": "9b26197216e9aafe",
+      "item": {
+        "type": "paragraph",
+        "id": "9b26197216e9aafe",
+        "text": "All sites, including uncategorized sites, will be included in the additional 'all' category made available to other plugins."
+      },
+      "date": 1433105990757
+    },
+    {
+      "type": "edit",
+      "id": "9b26197216e9aafe",
+      "item": {
+        "type": "paragraph",
+        "id": "9b26197216e9aafe",
+        "text": "All sites, including uncategorized sites, will be included in the 'all' category made available to other plugins."
+      },
+      "date": 1433106005345
+    },
+    {
+      "type": "edit",
+      "id": "9b26197216e9aafe",
+      "item": {
+        "type": "paragraph",
+        "id": "9b26197216e9aafe",
+        "text": "All sites, including uncategorized sites, will be included in the automatically created 'all' category."
+      },
+      "date": 1433106051744
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "d5ff937d77df0fd6"
+      },
+      "id": "d5ff937d77df0fd6",
+      "type": "add",
+      "after": "9b26197216e9aafe",
+      "date": 1433106160414
+    },
+    {
+      "type": "edit",
+      "id": "d5ff937d77df0fd6",
+      "item": {
+        "type": "paragraph",
+        "id": "d5ff937d77df0fd6",
+        "text": "Shift-double-click a Roster to see what categories are made available to other plugins."
+      },
+      "date": 1433106193664
+    },
+    {
+      "type": "add",
+      "item": {
+        "type": "paragraph",
+        "id": "fc6c3252b5da107a",
+        "text": "See [[About Activity Plugin]] for possible uses."
+      },
+      "after": "d5ff937d77df0fd6",
+      "id": "fc6c3252b5da107a",
+      "date": 1433106239320
+    },
+    {
+      "type": "add",
+      "id": "0ad4018c829ee9ef",
+      "item": {
+        "type": "paragraph",
+        "id": "0ad4018c829ee9ef",
+        "text": "A blank line of markup starts a new line in the Roster."
+      },
+      "after": "6ef5a3efa5295966",
+      "date": 1433106469381
+    },
+    {
+      "type": "edit",
+      "id": "fc6c3252b5da107a",
+      "item": {
+        "type": "paragraph",
+        "id": "fc6c3252b5da107a",
+        "text": "See [[About Activity Configuration]] for possible uses."
+      },
+      "date": 1433106685070
+    }
+  ]
+}

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -38,9 +38,30 @@ describe 'roster plugin', ->
       result = parse null, {text: 'fed.wiki.org'}
       expect(result).to.match />»<\/a><br>/
  
-  describe 'category', ->
+  describe 'category formatting', ->
 
     it 'end of line', ->
       result = parse null, {text: 'students'}
       expect(result).to.match /students *<br>/
+
+  describe 'category access', ->
+    stub =
+      addClass: (c) -> this.c = c
+      get: (n) -> this
+
+    it 'announces roster-source', ->
+      parse stub, {text: "wiki.org"}
+      expect(stub.c).to.be 'roster-source'
+
+    it 'has category all', ->
+      parse stub, {text: "wiki.org\nfoo.wiki.org"}
+      expect(stub.getRoster()).to.eql { all: [ 'wiki.org', 'foo.wiki.org' ] }
+
+    it 'allows prefix category name', ->
+      parse stub, {text: "ward\nwiki.org\nfoo.wiki.org"}
+      expect(stub.getRoster().ward).to.eql [ 'wiki.org', 'foo.wiki.org' ]
+
+    it 'allows sufix category name', ->
+      parse stub, {text: "wiki.org\nfoo.wiki.org\nward"}
+      expect(stub.getRoster().ward).to.eql [ 'wiki.org', 'foo.wiki.org' ]
 

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -1,13 +1,46 @@
 # build time tests for roster plugin
 # see http://mochajs.org/
 
-roster = require '../client/roster'
+{parse, includes} = require '../client/roster'
 expect = require 'expect.js'
 
 describe 'roster plugin', ->
 
-  describe 'expand', ->
+  describe 'site markup', ->
 
-    it 'can make itallic', ->
-      # result = roster.expand 'hello *world*'
-      # expect(result).to.be 'hello <i>world</i>'
+    it 'makes image', ->
+      result = parse null, {text: 'fed.wiki.org'}
+      expect(result).to.match /<img class="remote" src="\/\/fed.wiki.org\/favicon.png"/
+ 
+    it 'has title', ->
+      result = parse null, {text: 'fed.wiki.org'}
+      expect(result).to.match /title="fed.wiki.org"/
+ 
+    it 'has site data', ->
+      result = parse null, {text: 'fed.wiki.org'}
+      expect(result).to.match /data-site="fed.wiki.org"/
+ 
+    it 'has slug data', ->
+      result = parse null, {text: 'fed.wiki.org'}
+      expect(result).to.match /data-slug="welcome-visitors"/
+ 
+  describe 'end of line markup', ->
+
+    it 'has anchor', ->
+      result = parse null, {text: 'fed.wiki.org'}
+      expect(result).to.match /<a class='loadsites' href= "\/#"/
+ 
+    it 'has title', ->
+      result = parse null, {text: 'fed.wiki.org'}
+      expect(result).to.match /title="add these 1 sites\nto neighborhood"/
+ 
+    it 'has » at end of line', ->
+      result = parse null, {text: 'fed.wiki.org'}
+      expect(result).to.match />»<\/a><br>/
+ 
+  describe 'category', ->
+
+    it 'end of line', ->
+      result = parse null, {text: 'students'}
+      expect(result).to.match /students *<br>/
+


### PR DESCRIPTION
This pull request adds an include directive that simplifies cohort administration by building a remote address into a roster that would likely reside on pages forked by students.

```
INCLUDE wiki.example.com/late-class-roster
```

We include general tidying, documentation and tests.
